### PR TITLE
Fix login screen shadow and recovery bug

### DIFF
--- a/lib/auth/loader.dart
+++ b/lib/auth/loader.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 import 'package:lensysapp/auth/login.dart';
 import 'package:lensysapp/auth/register.dart';
-import 'package:lensysapp/custom/appcolors.dart';
 
 class LoaderScreen extends StatefulWidget {
   const LoaderScreen({super.key});
@@ -105,12 +104,14 @@ body: CustomPaint(
 }
 
 class DiagonalPainter extends CustomPainter {
-  const DiagonalPainter({required Color color});
+  final Color color;
+
+  const DiagonalPainter({required this.color});
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = AppColors.primary // usa el color principal definido en AppColors
+      ..color = color
       ..style = PaintingStyle.fill;
 
     final path = Path()

--- a/lib/auth/login.dart
+++ b/lib/auth/login.dart
@@ -73,7 +73,7 @@ class _LoginState extends State<Login> {
               borderRadius: BorderRadius.circular(20),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(),
+                  color: Colors.black.withOpacity(0.1),
                   blurRadius: 10,
                   offset: const Offset(0, 5),
                 ),

--- a/lib/auth/recovery.dart
+++ b/lib/auth/recovery.dart
@@ -16,8 +16,7 @@ class _RecoveryState extends State<Recovery> {
   Future<void> _recover() async {
     setState(() => _isLoading = true);
     final result = await AuthService().resetPassword(_emailController.text);
-    // ignore: unrelated_type_equality_checks
-    final bool success = result == true;
+    final bool success = result['success'] == true;
     setState(() => _isLoading = false);
 
     if (!mounted) return;
@@ -53,7 +52,7 @@ class _RecoveryState extends State<Recovery> {
               borderRadius: BorderRadius.circular(20),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(),
+                  color: Colors.black.withOpacity(0.1),
                   blurRadius: 10,
                   offset: const Offset(0, 5),
                 ),

--- a/lib/auth/register.dart
+++ b/lib/auth/register.dart
@@ -87,7 +87,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
               borderRadius: BorderRadius.circular(20),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(),
+                  color: Colors.black.withOpacity(0.1),
                   blurRadius: 10,
                   offset: const Offset(0, 5),
                 ),


### PR DESCRIPTION
## Summary
- correct BoxShadow color by using `withOpacity`
- fix recovery password success check
- clean up unused import and use parameterized color in `DiagonalPainter`
- minor style fixes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876185c263c8331a1caedb867eff037